### PR TITLE
modifying rules

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -7,117 +7,154 @@ import (
 	"strings"
 )
 
-// Rule is a boolean function if a match condition is found
-// in request is for matching
-// out request is for modifying outgoing request, as is in PathIsAt
-type Rule func(in *http.Request, out *http.Request) bool
+// Rule represents the structure for request matching and modification.
+// It consists of a Matcher, which determines if a rule is applicable for a request,
+// and a Modifier, which optionally alters the outgoing request when the rule criteria is met.
+type Rule struct {
+	// Matcher determines if the rule is applicable to a given request. It must be defined for every rule.
+	Matcher Matcher
 
-// Always always matches
+	// Modifier is an optional function to alter the outgoing request when the Matcher's criteria is satisfied.
+	Modifier Modifier
+}
+
+// Always creates a rule that always matches any request.
 func Always() Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		return true
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			return true
+		},
 	}
 }
 
-// HostMatches matches on the request host
+// HostMatches creates a rule that matches a request based on its host.
 func HostMatches(host string) Rule {
 	u, _ := url.Parse(host)
-	return func(in *http.Request, out *http.Request) bool {
-		return in.URL.Host == u.Host
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			return r.URL.Host == u.Host
+		},
 	}
 }
 
-// PathIsAt matches if request path is prepended by given path
-// also trims that path from outgoing request
+// PathIsAt creates a rule that matches if the request path starts with the specified path.
+// When the rule is satisfied, it also trims the matched path from the outgoing request.
 func PathIsAt(path string) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		hasPrefix := strings.HasPrefix(in.URL.Path, path)
-		if !hasPrefix {
-			return false
-		}
-		out.URL.Path = strings.TrimPrefix(out.URL.Path, path)
-		return true
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			return strings.HasPrefix(r.URL.Path, path)
+		},
+		Modifier: func(r *http.Request) {
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, path)
+		},
 	}
 }
 
-// IPMatches matches on the client IP from the X-Forwarded-For header
+// IPMatches creates a rule that matches a request based on the client IP derived from the X-Forwarded-For header.
 func IPMatches(clientIP string) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		xff := in.Header.Get("X-Forwarded-For")
-		ips := strings.Split(xff, ",")
-		return slices.Contains(ips, clientIP)
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			xff := r.Header.Get("X-Forwarded-For")
+			ips := strings.Split(xff, ",")
+			return slices.Contains(ips, clientIP)
+		},
 	}
 }
 
-// MethodMatches matches on the request method
+// MethodMatches creates a rule that matches a request based on its HTTP method.
 func MethodMatches(method string) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		return in.Method == method
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			return r.Method == method
+		},
 	}
 }
 
-// HasHeader matches if header key exists in request
+// HasHeader creates a rule that matches if the specified header key is present in the request.
 func HasHeader(header string) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		_, ok := in.Header[header]
-		return ok
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			_, ok := r.Header[header]
+			return ok
+		},
 	}
 }
 
-// HeaderContains matches if header kv pair exists in request
+// HeaderContains creates a rule that matches if the specified header key-value pair exists in the request.
 func HeaderContains(header string, value string) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		headerValues, ok := in.Header[header]
-		if !ok {
-			return false
-		}
-		return slices.Contains(headerValues, value)
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			headerValues, ok := r.Header[header]
+			if !ok {
+				return false
+			}
+			return slices.Contains(headerValues, value)
+		},
 	}
 }
 
-// HasQueryParam matches if query param key exists in request
+// HasQueryParam creates a rule that matches if the specified query parameter key exists in the request.
 func HasQueryParam(param string) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		values := in.URL.Query()[param]
-		return len(values) > 0
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			values := r.URL.Query()[param]
+			return len(values) > 0
+		},
 	}
 }
 
-// QueryParamContains matches if query param kv pair exists in request
+// QueryParamContains creates a rule that matches if the specified query parameter key-value pair exists in the request.
 func QueryParamContains(param string, value string) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		values := in.URL.Query()[param]
-		return slices.Contains(values, value)
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			values := r.URL.Query()[param]
+			return slices.Contains(values, value)
+		},
 	}
 }
 
-// HostPathIsAt matches on HostMatches and PathIsAt
+// HostPathIsAt creates a rule that matches a request based on both its host and path.
 func HostPathIsAt(hostpath string) Rule {
 	u, _ := url.Parse(hostpath)
 	return AllOf(HostMatches(u.Host), PathIsAt(u.Path))
 }
 
-// AllOf matches if all rules match
+// AllOf creates a composite rule that matches only if all of the provided rules are satisfied.
+// Modifiers of individual rules are applied in the order they are provided.
 func AllOf(rules ...Rule) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		for _, rule := range rules {
-			if !rule(in, out) {
-				return false
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			for _, rule := range rules {
+				if !rule.Matcher(r) {
+					return false
+				}
 			}
-		}
-		return true
+			return true
+		},
+		Modifier: func(r *http.Request) {
+			for _, rule := range rules {
+				if rule.Modifier != nil {
+					rule.Modifier(r)
+				}
+			}
+		},
 	}
 }
 
-// AnyOf matches if any rules match
+// AnyOf creates a composite rule that matches if any of the provided rules are satisfied.
+// The modifier of the first matching rule is used.
 func AnyOf(rules ...Rule) Rule {
-	return func(in *http.Request, out *http.Request) bool {
-		for _, rule := range rules {
-			if !rule(in, out) {
-				continue
+	var modifier Modifier
+	return Rule{
+		Matcher: func(r *http.Request) bool {
+			for _, rule := range rules {
+				if rule.Matcher(r) {
+					modifier = rule.Modifier
+					return true
+				}
 			}
-			return true
-		}
-		return false
+			return false
+		},
+		Modifier: modifier,
 	}
 }

--- a/rule_test.go
+++ b/rule_test.go
@@ -15,7 +15,7 @@ func TestBaseRule(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://localhost:8000/test", nil)
 
 	t.Run("Always match", func(t *testing.T) {
-		match := rule(req, nil)
+		match := rule.Matcher(req)
 		assert.True(t, match)
 	})
 }
@@ -28,12 +28,12 @@ func TestPathRule(t *testing.T) {
 	reqNoMatch, _ := http.NewRequest("GET", "http://localhost:8000/other/hello", nil)
 
 	t.Run("PathIsAt match", func(t *testing.T) {
-		match := rule(reqMatch, reqMatch)
+		match := rule.Matcher(reqMatch)
 		assert.True(t, match)
 	})
 
 	t.Run("PathIsAt no match", func(t *testing.T) {
-		match := rule(reqNoMatch, reqNoMatch)
+		match := rule.Matcher(reqNoMatch)
 		assert.False(t, match)
 	})
 }
@@ -49,12 +49,12 @@ func TestIPRule(t *testing.T) {
 	reqNoMatch.Header.Set("X-Forwarded-For", "192.168.1.3")
 
 	t.Run("IPMatches match", func(t *testing.T) {
-		match := rule(reqMatch, reqMatch)
+		match := rule.Matcher(reqMatch)
 		assert.True(t, match)
 	})
 
 	t.Run("IPMatches no match", func(t *testing.T) {
-		match := rule(reqNoMatch, reqNoMatch)
+		match := rule.Matcher(reqNoMatch)
 		assert.False(t, match)
 	})
 }
@@ -69,12 +69,12 @@ func TestHeaderRule(t *testing.T) {
 	reqNoMatch, _ := http.NewRequest("GET", "http://localhost:8000/test", nil)
 
 	t.Run("HasHeader match", func(t *testing.T) {
-		match := rule(reqMatch, reqMatch)
+		match := rule.Matcher(reqMatch)
 		assert.True(t, match)
 	})
 
 	t.Run("HasHeader no match", func(t *testing.T) {
-		match := rule(reqNoMatch, reqNoMatch)
+		match := rule.Matcher(reqNoMatch)
 		assert.False(t, match)
 	})
 }
@@ -93,17 +93,17 @@ func TestHeaderMatchesRule(t *testing.T) {
 	reqNoMatchHeader, _ := http.NewRequest("GET", "http://localhost:8000/test", nil)
 
 	t.Run("HeaderContains match", func(t *testing.T) {
-		match := rule(reqMatch, reqMatch)
+		match := rule.Matcher(reqMatch)
 		assert.True(t, match)
 	})
 
 	t.Run("HeaderContains no match value", func(t *testing.T) {
-		match := rule(reqNoMatchValue, reqNoMatchValue)
+		match := rule.Matcher(reqNoMatchValue)
 		assert.False(t, match)
 	})
 
 	t.Run("HeaderContains no match header", func(t *testing.T) {
-		match := rule(reqNoMatchHeader, reqNoMatchHeader)
+		match := rule.Matcher(reqNoMatchHeader)
 		assert.False(t, match)
 	})
 }


### PR DESCRIPTION
Allow `Rule` to define it's own modifier behaviour, seperating concerns of the in and out requests passed from `httputil.ReverseProxy.Rewrite`.